### PR TITLE
Update config.js for public-network-based development

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,7 @@ module.exports = (env) => {
       logLevel: 'silent',
       https: env.https || false,
       overlay: true,
-      host: '0.0.0.0',
+      host: env.host || 'localhost',
       port: 9000,
       proxy,
     },

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,7 @@ module.exports = (env) => {
       logLevel: 'silent',
       https: env.https || false,
       overlay: true,
+      host: '0.0.0.0',
       port: 9000,
       proxy,
     },


### PR DESCRIPTION
adding host information, allowing connection from public network.
I follow the official documentation for this : https://webpack.js.org/configuration/dev-server/#devserverhost

Use case : instead of dev on your laptop, you buy a public instance and code from this instance.
Without this PR it won't work, because the default host is 127.0.0.1 and does not accept external connection. 0.0.0.0 accept does.